### PR TITLE
Remove help trait as it is mostly a cli thing

### DIFF
--- a/src/adapters/operations.rs
+++ b/src/adapters/operations.rs
@@ -1,13 +1,3 @@
-mod help {
-    pub trait HelpOperations {
-        /// Get an help for the struct implementing this trait
-        fn help(&self) -> String;
-
-        /// Get an help for a specific command of the struct implementing this trait
-        fn help_command(&self, command: String) -> String;
-    }
-}
-
 pub mod device {
     use crate::models::secondary_device::{Device, DeviceFactory, DeviceFactoryKey};
 


### PR DESCRIPTION
In my opinion, this is not the role of core to know how to use the CLI. It would rather be some cli module that defines that. 